### PR TITLE
Add Teams and Riders overview

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import CyclistComponent from './cyclist/CyclistComponent';
 
 import React, { Component } from 'react'
 import TeamComponent from './teams/TeamComponent';
+import TeamsComponent from './teams/TeamsComponent';
 import Header from './Header';
 
 class App extends Component {
@@ -30,6 +31,7 @@ class App extends Component {
           <Route path='/calendar/:year' render={(props) => <CalendarComponent {...props} />} />
           <Route path='/cyclist/:cyc_id/:year' render={(props) => <CyclistComponent {...props} />} />
           <Route path='/team/:team_id/:year' render={(props) => <TeamComponent {...props} />}/>
+          <Route path='/teams/:year' render={(props) => <TeamsComponent {...props} />}/>
         </Switch>
       </div>
     )

--- a/src/App.js
+++ b/src/App.js
@@ -3,10 +3,11 @@ import RaceResult from './race/RaceResult';
 import { Route, Switch, withRouter } from 'react-router-dom';
 import CalendarComponent from './CalendarComponent';
 import CyclistComponent from './cyclist/CyclistComponent';
+import CyclistListComponent from './cyclist/CyclistListComponent'
 
 import React, { Component } from 'react'
 import TeamComponent from './teams/TeamComponent';
-import TeamsComponent from './teams/TeamsComponent';
+import TeamListComponent from './teams/TeamListComponent';
 import Header from './Header';
 
 class App extends Component {
@@ -30,8 +31,9 @@ class App extends Component {
           <Route path='/race/:race_id/:year' render={(props) => <RaceResult {...props} />} />
           <Route path='/calendar/:year' render={(props) => <CalendarComponent {...props} />} />
           <Route path='/cyclist/:cyc_id/:year' render={(props) => <CyclistComponent {...props} />} />
+          <Route path='/cyclists/:year' render={(props) => <CyclistListComponent {...props} />} />
           <Route path='/team/:team_id/:year' render={(props) => <TeamComponent {...props} />}/>
-          <Route path='/teams/:year' render={(props) => <TeamsComponent {...props} />}/>
+          <Route path='/teams/:year' render={(props) => <TeamListComponent {...props} />}/>
         </Switch>
       </div>
     )

--- a/src/CalendarComponent.js
+++ b/src/CalendarComponent.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import Calendar from './assets/Calendar'
 import './styling.css'
 import Flag from './icons/Flag'
+import seasons from './assets/Seasons'
 
 export default class CalendarComponent extends Component {
 
@@ -9,7 +10,8 @@ export default class CalendarComponent extends Component {
         super(props)
 
         this.state = {
-            calendar: null
+            calendar: null,
+            availableYears: Object.keys(seasons())
         }
     }
 
@@ -34,7 +36,10 @@ export default class CalendarComponent extends Component {
             <div style={{ marginLeft: 180 }}>
                 <div style={{ display: 'flex' }}>
                     <h2>Calendar</h2>
-                    <h2 style={{ marginLeft: 16, color: 'steelblue' }}>{this.state.year}</h2>
+                    {this.state.availableYears.map(year =>
+                        this.state.year == year
+                        ? <h2 style={{ marginLeft: 16, color: 'steelblue' }}>{this.state.year}</h2>
+                        : <h2 className="select-year" style={{ marginLeft: 16 }} onClick={() => this.props.history.push('/calendar/' + year)}>{year}</h2>)}
                 </div>
                 {this.state.calendar && this.state.calendar.data.map(item => <div style={{ display: 'flex' }} key={item.id}>
                     <div className="table-item" style={{ width: 32 }}>{item.race_data.start_date}</div>

--- a/src/Header.js
+++ b/src/Header.js
@@ -14,9 +14,10 @@ export default class Header extends Component {
         return (
             <div>
                 <div style={{textAlign: "right", marginRight: 120, marginTop: 20}}>
-                    <div className="button-header"onClick={() => this.props.history.push('/calendar/2018')}>2018</div>
-                    <div className="button-header"onClick={() => this.props.history.push('/calendar/2019')}>2019</div>
-                    <div className="button-header"onClick={() => this.props.history.push('/calendar/2020')}>2020</div>
+                    <div className="button-header"onClick={() => this.props.history.push('/teams/2020')}>Teams</div>
+                    <div className="button-header"onClick={() => this.props.history.push('/riders/2020')}>Riders</div>
+                    <div className="button-header"onClick={() => this.props.history.push('/races/2020')}>Races</div>
+                    <div className="button-header"onClick={() => this.props.history.push('/calendar/2020')}>Calendar</div>
                 </div>
             </div>
         )

--- a/src/Header.js
+++ b/src/Header.js
@@ -15,8 +15,7 @@ export default class Header extends Component {
             <div>
                 <div style={{textAlign: "right", marginRight: 120, marginTop: 20}}>
                     <div className="button-header"onClick={() => this.props.history.push('/teams/2020')}>Teams</div>
-                    <div className="button-header"onClick={() => this.props.history.push('/riders/2020')}>Riders</div>
-                    <div className="button-header"onClick={() => this.props.history.push('/races/2020')}>Races</div>
+                    <div className="button-header"onClick={() => this.props.history.push('/cyclists/2020')}>Riders</div>
                     <div className="button-header"onClick={() => this.props.history.push('/calendar/2020')}>Calendar</div>
                 </div>
             </div>

--- a/src/assets/Cyclist.js
+++ b/src/assets/Cyclist.js
@@ -36,6 +36,10 @@ class Cyclist {
         return season ? season.team : undefined
     }
 
+    getContractYears() {
+        return this.seasons.filter(season => season.team != 'team_119').map(season => season.year).sort()
+    }
+
     getResults(year) {
         let cyclist_results = []
         results(year).forEach(x => {

--- a/src/assets/CyclistList.js
+++ b/src/assets/CyclistList.js
@@ -1,0 +1,18 @@
+import cyclists from '../data/cyclists.json'
+import Cyclist from './Cyclist'
+import '../styling.css'
+
+class CyclistList {
+
+    cyclistList
+
+    constructor(year) {
+        if(year == 'All') {
+            this.cyclistList = cyclists.map(cyclist => ({cyclist: new Cyclist(cyclist.id), season: cyclist.seasons.filter(season => season.team != 'team_119').sort((a, b) => b.year - a.year)[0]})).filter(cyclist => cyclist.season)
+        } else {
+            this.cyclistList = cyclists.map(cyclist => ({cyclist: new Cyclist(cyclist.id), season: cyclist.seasons.find(season => season.year == year && season.team != 'team_119')})).filter(cyclist => cyclist.season)
+        }
+    }
+}
+
+export default CyclistList

--- a/src/assets/Result.js
+++ b/src/assets/Result.js
@@ -1,15 +1,7 @@
-import Res2018 from '../data/results_2018.json'
-import Res2019 from '../data/results_2019.json'
-import Res2020 from '../data/results_2020.json'
+import seasons from './Seasons'
 import Race from './Race'
 import Cyclist from './Cyclist'
 import Team from './Team'
-
-const Results = {
-    '2018': Res2018,
-    '2019': Res2019,
-    '2020': Res2020
-}
 
 class Result {
 
@@ -19,7 +11,7 @@ class Result {
     race_data
 
     constructor(race_id, year) {
-        let result = Results[year].find(element => element.id === race_id)
+        let result = seasons()[year].find(element => element.id === race_id)
         Object.assign(this, result)
         if(result)
             this.race_data = new Race(race_id).seasons.find(element => element.year == year)
@@ -48,8 +40,6 @@ class Result {
 class ResultTable {
 
     tables
-    images
-    video
 
     constructor(results, tag) {
         let result = results.find(element => element.tag === tag)

--- a/src/assets/Results.js
+++ b/src/assets/Results.js
@@ -1,15 +1,7 @@
-import Res2018 from '../data/results_2018.json'
-import Res2019 from '../data/results_2019.json'
-import Res2020 from '../data/results_2020.json'
-
-const seasons = {
-    '2018': Res2018,
-    '2019': Res2019,
-    '2020': Res2020
-}
+import seasons from './Seasons'
 
 function results(year) {
-    return seasons[year]
+    return seasons()[year]
 }
 
 export default results

--- a/src/assets/Seasons.js
+++ b/src/assets/Seasons.js
@@ -1,0 +1,15 @@
+import Res2018 from '../data/results_2018.json'
+import Res2019 from '../data/results_2019.json'
+import Res2020 from '../data/results_2020.json'
+
+const racedSeasons = {
+    '2018': Res2018,
+    '2019': Res2019,
+    '2020': Res2020
+}
+
+function seasons() {
+    return racedSeasons;
+}
+
+export default seasons

--- a/src/assets/Team.js
+++ b/src/assets/Team.js
@@ -16,7 +16,7 @@ class Team {
     }
 
     getTeam(year) {
-        return this.seasons.find(season => season.year == year)
+        return this.seasons && this.seasons.find(season => season.year == year)
     }
 
     getCyclists(year) {
@@ -26,6 +26,10 @@ class Team {
         })
         cyclists_team = cyclists_team.sort((a,b) => a.lastname + a.firstname > b.lastname + b.firstname)
         return cyclists_team.map(cyclist => new Cyclist(cyclist.id))
+    }
+
+    getSeasons() {
+        return this.seasons.map(season => season.year).sort()
     }
 
     /*getFlagId(year) {

--- a/src/assets/TeamList.js
+++ b/src/assets/TeamList.js
@@ -1,0 +1,17 @@
+import teams from '../data/teams.json'
+import '../styling.css'
+
+class TeamList {
+
+    teamList
+
+    constructor(year) {
+        if(year == 'All') {
+            this.teamList = teams.map(team => ({id: team.id, season: team.seasons.sort((a, b) => b.year - a.year)[0]}))
+        } else {
+            this.teamList = teams.map(team => ({id: team.id, season: team.seasons.find(season => season.year == year)})).filter(team => team.season)
+        }
+    }
+}
+
+export default TeamList

--- a/src/cyclist/CyclistComponent.js
+++ b/src/cyclist/CyclistComponent.js
@@ -22,6 +22,15 @@ export default class CyclistComponent extends Component {
         this.getCyclist(cyc_id, year)
     }
 
+    componentDidUpdate() {
+        const { year } = this.props.match.params
+        if (this.state.year != year) {
+            const { year } = this.props.match.params
+            this.setState({ year: year, cyc_id: this.state.cyclist.id })
+            this.getCyclist(this.state.cyclist.id, year)
+        }
+    }
+
     getCyclist(cyc_id, year) {
         let cyclist = new Cyclist(cyc_id)
         let team = new Team(cyclist.getTeam(year))
@@ -51,7 +60,13 @@ export default class CyclistComponent extends Component {
                         <Flag tag={this.state.cyclist.getFlagId()} size={40} />
                     </div>
                     <h2>{this.state.cyclist.firstname + ' ' + this.state.cyclist.lastname}</h2>
-                    <h2 style={{ marginLeft: 16, color: 'steelblue' }}>{this.state.team.name}</h2>
+                    <h2 className="button-header" style={{ marginLeft: 16, color: 'steelblue' }} onClick={() => this.props.history.push('/team/' + this.state.cyclist.getTeam(this.state.year) + '/' + this.state.year)}>{this.state.team.name}</h2>
+                </div>}
+                {this.state.cyclist && <div style={{ display: 'flex'}}>
+                    {this.state.cyclist.getContractYears().map(year =>
+                        this.state.year == year
+                        ? <h2 style={{ marginLeft: 16, marginTop: 0, color: 'steelblue' }}>{this.state.year}</h2>
+                        : <h2 className="select-year" style={{ marginLeft: 16, marginTop: 0 }} onClick={() => this.props.history.push('/cyclist/' + this.state.cyclist.id + '/' + year)}>{year}</h2>)}
                 </div>}
                 {this.state.results && <div>
                     {this.state.results.map(result => <CyclistResult 

--- a/src/cyclist/CyclistListComponent.js
+++ b/src/cyclist/CyclistListComponent.js
@@ -1,0 +1,68 @@
+import React, { Component } from 'react'
+import '../styling.css'
+import CyclistList from '../assets/CyclistList'
+import cyclists from '../data/cyclists.json'
+import Flag from '../icons/Flag'
+import Team from '../assets/Team'
+
+export default class TeamListComponent extends Component {
+
+    constructor(props) {
+        super(props)
+
+        this.state = {
+            cyclists: [],
+            availableYears: ['All', ...cyclists.flatMap(cyclist => cyclist.seasons.map(season => season.year)).filter((v, i, s) => s.indexOf(v) === i).sort()]
+        }
+    }
+
+
+    componentDidMount() {
+        const { year } = this.props.match.params
+        let cyclistList = new CyclistList(year).cyclistList.sort((a, b) => a.cyclist.fullname().localeCompare(b.cyclist.fullname()))
+        console.log(cyclistList)
+        this.setState({ cyclists: cyclistList, year: year })
+    }
+
+    componentDidUpdate() {
+        const { year } = this.props.match.params
+        if (this.state.year != year) {
+            const { year } = this.props.match.params
+            let cyclistList = new CyclistList(year).cyclistList.sort((a, b) => a.cyclist.fullname().localeCompare(b.cyclist.fullname()))
+            this.setState({ cyclists: cyclistList, year: year })
+        }
+    }
+
+    render() {
+        return (
+            <div style={{ marginLeft: 180 }}>
+                <div style={{ display: 'flex' }}>
+                    <h2>Cyclists</h2>
+                    {this.state.availableYears.map(year =>
+                        this.state.year == year
+                        ? <h2 style={{ marginLeft: 16, color: 'steelblue' }}>{this.state.year}</h2>
+                        : <h2 className="select-year" style={{ marginLeft: 16 }} onClick={() => this.props.history.push('/cyclists/' + year)}>{year}</h2>)}
+                </div>
+                {this.state.year == "All" && <div style={{ display: 'flex'}} key="header">
+                    <div className="table-item" style={{ width: 338 }}><i style={{ marginLeft: 22 }}>Rider Name</i></div>
+                    <div className="table-item" style={{ width: 320 }}><i style={{ marginLeft: 4 }}>Team</i></div>
+                    <div className="table-item" style={{ width: 100 }}><i style={{ marginLeft: 4 }}>Last Contract</i></div>
+                </div>}
+                {this.state.cyclists && this.state.cyclists.map(cyclistEntry => <div style={{ display: 'flex' }} key={cyclistEntry.cyclist.id}>
+                    <div className="table-item-link" style={{ display: 'flex' }}
+                        onClick={() => this.props.history.push('/cyclist/' + cyclistEntry.cyclist.id + '/' + cyclistEntry.season.year)}>
+                        <div style={{ marginTop: 0 }}>
+                            <Flag tag={cyclistEntry.cyclist.getFlagId()} size={18} />
+                        </div>
+                        <div style={{ marginLeft: 4, width: 320 }}>{cyclistEntry.cyclist.fullname()}</div>
+                    </div>
+                    <div className="table-item-link" style={{ width: 320 }}
+                        onClick={() => this.props.history.push('/team/' + cyclistEntry.season.team + '/' + cyclistEntry.season.year)}>
+                            {cyclistEntry.season.team ? new Team(cyclistEntry.season.team).getTeam(cyclistEntry.season.year)?.name : 'unknown'}
+                    </div>
+                    {this.state.year == "All" && <div className="table-item" style={{ width: 100}}>{cyclistEntry.season.year}</div>}
+                </div>)}
+            </div>
+        )
+    }
+}

--- a/src/cyclist/CyclistResult.js
+++ b/src/cyclist/CyclistResult.js
@@ -57,7 +57,7 @@ export default class CyclistResult extends Component {
                             <div style={{ marginLeft: 4 }}>{this.state.race.race_data.name}</div>
                         </div>
                     </div>
-                    {this.state.stageResults.map(stage => <CyclistStageRow key={stage.name} stage={stage} />)}
+                    {this.state.stageResults.map(stage => <CyclistStageRow key={stage.name} stage={stage} raceId={this.state.race.race.id} year={this.state.year} history={this.props.history} />)}
                 </div>}
             </div>
         )

--- a/src/cyclist/CyclistStageRow.js
+++ b/src/cyclist/CyclistStageRow.js
@@ -11,11 +11,14 @@ export default class CyclistStageRow extends Component {
     }
 
     componentDidMount() {
+        let raceId = this.props.raceId
+        let year = this.props.year
         let name = this.props.stage.name
         let results = this.props.stage.results
         let positions = {}
+        let tag = results ? results[0].tag : undefined
         results.forEach(result => positions[result.classification] = result.position)
-        this.setState({ name: name, positions: positions })
+        this.setState({ raceId: raceId, year: year, name: name, positions: positions, tag: tag })
     }
 
     render() {
@@ -25,7 +28,7 @@ export default class CyclistStageRow extends Component {
                     <div style={{ width: 40, paddingLeft: 10 }} className='table-item'>
                         {this.state.positions.main && this.state.positions.main}
                     </div>
-                    <div className='table-item-link' style={{ display: 'flex', width: 180 }}>
+                    <div className='table-item-link' style={{ display: 'flex', width: 180 }} onClick={() => this.state.tag && this.props.history.push('/race/' + this.state.raceId + '/' + this.state.year + '/' + this.state.tag)}>
                         <div style={{ marginLeft: 4 }}>{this.state.name}</div>
                     </div>
                     <div className='table-item' style={{ width: 240, display: 'flex' }}>

--- a/src/race/RaceResult.js
+++ b/src/race/RaceResult.js
@@ -19,7 +19,6 @@ export default class RaceResult extends Component {
 
     getResult = (race_id, year, tag) => {
         let result = new Result(race_id, year)
-        console.log(result)
         this.setState({ results: result.results, race_data: result.race_data, selector: tag },() => this.setTable(tag, 'main'))
     }
 

--- a/src/styling.css
+++ b/src/styling.css
@@ -20,9 +20,16 @@
 
 .button-header {
     display: inline-block;
-    width: 50px;
+    padding-right: 20px;
 }
 
 .button-header:hover {
+    cursor: pointer;
+}
+
+h2.select-year {
+    margin-left: 15px;
+    align-self: center;
+    color: darkgray;
     cursor: pointer;
 }

--- a/src/teams/TeamComponent.js
+++ b/src/teams/TeamComponent.js
@@ -17,22 +17,34 @@ export default class TeamComponent extends Component {
         this.getTeam(team_id, year)
     }
 
+    componentDidUpdate() {
+        const { year } = this.props.match.params
+        if (this.state.year != year) {
+            const { team_id, year } = this.props.match.params
+            this.setState({ year: year, team_id: team_id })
+            this.getTeam(team_id, year)
+        }
+    }
+
     getTeam(team_id, year) {
         let team = new Team(team_id)
         let cyclists = team.getCyclists(year)
         let team_season = team.getTeam(year)
-        this.setState({ cyclists: cyclists, team: team_season })
+        this.setState({ cyclists: cyclists, teamSeason: team_season, team: team })
     }
 
     render() {
         return (
             <div style={{ marginLeft: 180 }}>
-                {this.state.team && <div style={{ display: 'flex' }}>
+                {this.state.teamSeason && <div style={{ display: 'flex' }}>
                     {/*<div style={{ marginTop: 14, marginRight: 8 }}>
                         <Flag tag={this.state.race_data.country.getFlagId()} size={40} />
                     </div>*/}
-                    <h2>{this.state.team.name}</h2>
-                    <h2 style={{ marginLeft: 16, color: 'steelblue' }}>{this.state.year}</h2>
+                    <h2>{this.state.teamSeason.name}</h2>
+                    {this.state.team.getSeasons().map(year =>
+                        this.state.year == year
+                        ? <h2 style={{ marginLeft: 16, color: 'steelblue' }}>{this.state.year}</h2>
+                        : <h2 className="select-year" style={{ marginLeft: 16 }} onClick={() => this.props.history.push('/team/' + this.state.team.id + '/' + year)}>{year}</h2>)}
                 </div>}
                 <div style={{ width: 320 }}>
                     {this.state.cyclists && this.state.cyclists.map(cyclist => <div id={cyclist.id} className="table-item-link" style={{ width: 200 }} style={{ display: 'flex' }}

--- a/src/teams/TeamComponent.js
+++ b/src/teams/TeamComponent.js
@@ -35,7 +35,7 @@ export default class TeamComponent extends Component {
                     <h2 style={{ marginLeft: 16, color: 'steelblue' }}>{this.state.year}</h2>
                 </div>}
                 <div style={{ width: 320 }}>
-                    {this.state.cyclists && this.state.cyclists.map(cyclist => <div className="table-item-link" style={{ width: 200 }} style={{ display: 'flex' }}
+                    {this.state.cyclists && this.state.cyclists.map(cyclist => <div id={cyclist.id} className="table-item-link" style={{ width: 200 }} style={{ display: 'flex' }}
                         onClick={() => this.props.history.push('/cyclist/' + cyclist.id + '/' + this.state.year)}>
                         <div style={{ marginTop: 0 }}>
                             <Flag tag={cyclist.getFlagId()} size={18} />

--- a/src/teams/TeamListComponent.js
+++ b/src/teams/TeamListComponent.js
@@ -3,7 +3,7 @@ import '../styling.css'
 import TeamList from '../assets/TeamList'
 import teams from '../data/teams.json'
 
-export default class TeamsComponent extends Component {
+export default class TeamListComponent extends Component {
 
     constructor(props) {
         super(props)
@@ -41,12 +41,12 @@ export default class TeamsComponent extends Component {
                         : <h2 className="select-year" style={{ marginLeft: 16 }} onClick={() => this.props.history.push('/teams/' + year)}>{year}</h2>)}
                 </div>
                 {this.state.year == "All" && <div style={{ display: 'flex'}} key="header">
-                    <div className="table-item" style={{ width: 280 }}><i>Team Name</i></div>
+                    <div className="table-item" style={{ width: 320 }}><i>Team Name</i></div>
                     <div className="table-item" style={{ width: 72 }}><i>Division</i></div>
-                    <div className="table-item" style={{ width: 72 }}><i>Last Season</i></div>
+                    <div className="table-item" style={{ width: 72 }}><i>Last Raced</i></div>
                 </div>}
                 {this.state.teams && this.state.teams.map(item => <div style={{ display: 'flex' }} key={item.id}>
-                    <div className="table-item-link" style={{ width: 280 }} 
+                    <div className="table-item-link" style={{ width: 320 }} 
                         onClick={() => this.props.history.push('/team/' + item.id + '/' + item.season.year)}
                     >{item.season.name && <div>
                         {item.season.name}

--- a/src/teams/TeamsComponent.js
+++ b/src/teams/TeamsComponent.js
@@ -1,0 +1,60 @@
+import React, { Component } from 'react'
+import '../styling.css'
+import TeamList from '../assets/TeamList'
+import teams from '../data/teams.json'
+
+export default class TeamsComponent extends Component {
+
+    constructor(props) {
+        super(props)
+
+        this.state = {
+            teams: [],
+            availableYears: ['All', ...teams.flatMap(team => team.seasons.map(season => season.year)).filter((v, i, s) => s.indexOf(v) === i).sort()]
+        }
+    }
+
+
+    componentDidMount() {
+        const { year } = this.props.match.params
+        let teamList = new TeamList(year).teamList.sort((a, b) => a.season.name.localeCompare(b.season.name))
+        this.setState({ teams: teamList, year: year })
+    }
+
+    componentDidUpdate() {
+        const { year } = this.props.match.params
+        if (this.state.year != year) {
+            const { year } = this.props.match.params
+            let teamList = new TeamList(year).teamList.sort((a, b) => a.season.name.localeCompare(b.season.name))
+            this.setState({ teams: teamList, year: year })
+        }
+    }
+
+    render() {
+        return (
+            <div style={{ marginLeft: 180 }}>
+                <div style={{ display: 'flex' }}>
+                    <h2>Teams</h2>
+                    {this.state.availableYears.map(year =>
+                        this.state.year == year
+                        ? <h2 style={{ marginLeft: 16, color: 'steelblue' }}>{this.state.year}</h2>
+                        : <h2 className="select-year" style={{ marginLeft: 16 }} onClick={() => this.props.history.push('/teams/' + year)}>{year}</h2>)}
+                </div>
+                {this.state.year == "All" && <div style={{ display: 'flex'}} key="header">
+                    <div className="table-item" style={{ width: 280 }}><i>Team Name</i></div>
+                    <div className="table-item" style={{ width: 72 }}><i>Division</i></div>
+                    <div className="table-item" style={{ width: 72 }}><i>Last Season</i></div>
+                </div>}
+                {this.state.teams && this.state.teams.map(item => <div style={{ display: 'flex' }} key={item.id}>
+                    <div className="table-item-link" style={{ width: 280 }} 
+                        onClick={() => this.props.history.push('/team/' + item.id + '/' + item.season.year)}
+                    >{item.season.name && <div>
+                        {item.season.name}
+                    </div>}</div>
+                    <div className="table-item" style={{ width: 72 }}>{item.season.div}</div>
+                    {this.state.year == "All" && <div className="table-item" style={{ width: 72 }}>{item.season.year}</div>}
+                </div>)}
+            </div>
+        )
+    }
+}


### PR DESCRIPTION
- Basic navigation modified; no longer calendar for 2018, 2019 and 2020, but for teams, riders, and calendar
- Year selection for calendar is now on calendar page; default is 2020
- Team list and Riders list added with selection per year or "All" option
- Riders and Teams have now navigation for years they were active, no more need to manually modify the URL